### PR TITLE
Change name and maven meta

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,10 +2,10 @@
 <plugin>
     <author>igniterealtime.org</author>
     <class>org.ifsoft.irma.openfire.PluginImpl</class>
-    <name>IRMA</name>
-    <description>I Reveal My Attributes to Openfire</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
+    <version>${project.version}</version>
     <licenseType>Apache 2.0</licenseType>
-    <version>0.0.1</version>
     <date>09/11/2019</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,11 @@
     </parent>
     
     <groupId>org.igniterealtime.openfire</groupId>
-    <artifactId>irma</artifactId>
-    <version>0.0.1</version>
+    <artifactId>irmaserver</artifactId>
+    <version>0.0.2-SNAPSHOT</version>
 
+    <name>IRMA Server</name>
+    <description>Provides an 'I Reveal My Attributes' (IRMA) server embedded in Openfire.</description>
     <build>
         <sourceDirectory>src/java</sourceDirectory> 
         <plugins>


### PR DESCRIPTION
This commit:
- changes the name of the plugin from 'irma' to 'irmaserver' (to prevent clashes with the other IRMA plugin)
- updates the version from 0.0.1 to 0.0.2-SNAPSHOT
- moves metadata from plugin.xml to pom.xml, using placeholders in plugin.xml to read back the data