### PR TITLE
fixes #4: NPE when acces admin console page

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ IRMA Plugin Changelog
 
 <ul>
     <li><a href="https://github.com/igniterealtime/openfire-irmaserver-plugin/issues/2">#2</a>: i18n file can't be loaded</li>
+    <li><a href="https://github.com/igniterealtime/openfire-irmaserver-plugin/issues/4">#4</a>: NPE when access admin console page</li>
 </ul>
 
 <p><b>0.0.1</b> -- September 11, 2019</p>

--- a/src/web/irma.jsp
+++ b/src/web/irma.jsp
@@ -11,7 +11,7 @@
     String errorMessage = null;
 
     // Get handle on the plugin
-    PluginImpl plugin = (PluginImpl) XMPPServer.getInstance().getPluginManager().getPlugin("irma");
+    PluginImpl plugin = (PluginImpl) XMPPServer.getInstance().getPluginManager().getPlugin("irmaserver");
 
     if (update)
     {    


### PR DESCRIPTION
The admin console page tries to load the plugin using a different name (I'm assuming it got renamed at some point), which causes a NullPointerException to be logged.

This commit fixes the name of the plugin that's being loaded.